### PR TITLE
refactor(extractor): add Registry pattern with auto-discovery for extractors

### DIFF
--- a/src/treco/http/__init__.py
+++ b/src/treco/http/__init__.py
@@ -7,10 +7,6 @@ This module provides HTTP request handling, parsing, and data extraction.
 from typing import Any
 from .client import HTTPClient
 from .parser import HTTPParser
-from .extractor import RegExExtractor
+from .extractor import ExtractorRegistry, get_extractor
 
-Extractors: dict[str, Any] = {
-    "regex": RegExExtractor,
-}
-
-__all__ = ["HTTPClient", "HTTPParser", "Extractors"]
+__all__ = ["HTTPClient", "HTTPParser", "ExtractorRegistry", "get_extractor"]

--- a/src/treco/http/extractor/base.py
+++ b/src/treco/http/extractor/base.py
@@ -4,7 +4,10 @@ Defines the base classes and interfaces for data extractors.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
+from typing import Dict, Type, List, Optional
+from pathlib import Path
+import pkgutil
+import importlib
 import requests
 
 
@@ -15,6 +18,9 @@ class BaseExtractor(ABC):
     Extractors are responsible for extracting structured data
     from HTTP responses based on specific extraction logic.
     """
+
+    _extractor_type: str = ""
+    _extractor_aliases: List[str] = []
 
     @abstractmethod
     def extract(self, response: requests.Response, pattern: str) -> Optional[str]:
@@ -29,3 +35,193 @@ class BaseExtractor(ABC):
             Dictionary of extracted variables
         """
         pass
+
+class ExtractorRegistry:
+    """
+    Registry for extractor classes.
+    
+    Maintains a mapping of extractor types (and aliases) to their implementing classes.
+    Supports auto-discovery of extractors in the package directory.
+    """
+    
+    _extractors: Dict[str, Type["BaseExtractor"]] = {}
+    _discovered: bool = False
+    
+    @classmethod
+    def register(
+        cls, 
+        extractor_type: str, 
+        aliases: Optional[List[str]] = None
+    ):
+        """
+        Decorator to register an extractor class.
+        
+        Args:
+            extractor_type: Primary identifier for the extractor (e.g., 'regex', 'jpath')
+            aliases: Optional list of alternative names for the extractor
+            
+        Returns:
+            Decorator function
+            
+        Example:
+            @register_extractor('jpath', aliases=['jsonpath', 'json_path'])
+            class JPathExtractor(BaseExtractor):
+                ...
+        """
+        aliases = aliases or []
+        
+        def decorator(extractor_cls: Type["BaseExtractor"]) -> Type["BaseExtractor"]:
+            # Register primary type
+            cls._extractors[extractor_type] = extractor_cls
+            
+            # Register all aliases
+            for alias in aliases:
+                cls._extractors[alias] = extractor_cls
+            
+            # Store metadata on the class for introspection
+            extractor_cls._extractor_type = extractor_type
+            extractor_cls._extractor_aliases = aliases
+            
+            return extractor_cls
+        
+        return decorator
+    
+    @classmethod
+    def get(cls, extractor_type: str) -> Type["BaseExtractor"]:
+        """
+        Get an extractor class by type or alias.
+        
+        Args:
+            extractor_type: The type or alias of the extractor
+            
+        Returns:
+            The extractor class
+            
+        Raises:
+            UnknownExtractorError: If no extractor is registered for the given type
+        """
+        # Ensure discovery has run
+        cls.discover()
+        
+        if extractor_type not in cls._extractors:
+            raise UnknownExtractorError(
+                f"Unknown extractor type: '{extractor_type}'. "
+                f"Available types: {list(cls.get_registered_types())}"
+            )
+        return cls._extractors[extractor_type]
+    
+    @classmethod
+    def get_instance(cls, extractor_type: str) -> "BaseExtractor":
+        """
+        Get an instance of an extractor by type or alias.
+        
+        Args:
+            extractor_type: The type or alias of the extractor
+            
+        Returns:
+            An instance of the extractor class
+        """
+        extractor_cls = cls.get(extractor_type)
+        return extractor_cls()
+    
+    @classmethod
+    def get_registered_types(cls) -> List[str]:
+        """
+        Get all registered extractor types (excluding aliases).
+        
+        Returns:
+            List of primary extractor type identifiers
+        """
+        cls.discover()
+        
+        # Return only primary types, not aliases
+        seen = set()
+        types = []
+        for type_name, extractor_cls in cls._extractors.items():
+            if extractor_cls not in seen:
+                seen.add(extractor_cls)
+                types.append(getattr(extractor_cls, '_extractor_type', type_name))
+        return types
+    
+    @classmethod
+    def get_all_names(cls) -> List[str]:
+        """
+        Get all registered names (types and aliases).
+        
+        Returns:
+            List of all registered identifiers
+        """
+        cls.discover()
+        return list(cls._extractors.keys())
+    
+    @classmethod
+    def discover(cls) -> None:
+        """
+        Auto-discover and import all extractor modules in the package.
+        
+        This method imports all Python modules in the extractor package directory,
+        triggering their @register_extractor decorators to register them.
+        """
+        if cls._discovered:
+            return
+        
+        # Get the package directory
+        package_dir = Path(__file__).parent
+        package_name = "treco.http.extractor"
+        
+        # Import all modules in the package
+        for module_info in pkgutil.iter_modules([str(package_dir)]):
+            module_name = module_info.name
+            
+            # Skip special modules
+            if module_name in ('__init__', 'base', 'registry'):
+                continue
+            
+            # Import the module to trigger registration
+            full_module_name = f"{package_name}.{module_name}"
+            try:
+                importlib.import_module(full_module_name)
+            except ImportError as e:
+                # Log but don't fail - allows graceful degradation
+                import logging
+                logging.getLogger(__name__).warning(
+                    f"Failed to import extractor module '{full_module_name}': {e}"
+                )
+        
+        cls._discovered = True
+    
+    @classmethod
+    def reset(cls) -> None:
+        """
+        Reset the registry. Primarily useful for testing.
+        """
+        cls._extractors.clear()
+        cls._discovered = False
+
+
+class UnknownExtractorError(Exception):
+    """Raised when an unknown extractor type is requested."""
+    pass
+
+
+# Convenience function for the decorator
+def register_extractor(
+    extractor_type: str, 
+    aliases: Optional[List[str]] = None
+):
+    """
+    Decorator to register an extractor class.
+    
+    Args:
+        extractor_type: Primary identifier for the extractor
+        aliases: Optional list of alternative names
+        
+    Returns:
+        Decorator function
+        
+    Example:
+        @register_extractor('regex', aliases=['re', 'regexp'])
+        class RegExExtractor(BaseExtractor):
+            ...
+    """
+    return ExtractorRegistry.register(extractor_type, aliases)

--- a/src/treco/http/extractor/jpath.py
+++ b/src/treco/http/extractor/jpath.py
@@ -1,12 +1,24 @@
-from typing import Any, Optional, List
-import json
+"""
+JSONPath extractor module.
+
+Extracts data from JSON responses using JSONPath expressions.
+"""
+
+from typing import Any, Optional
 from jsonpath_ng import parse
-from treco.http.extractor.base import BaseExtractor
 import requests
 
+from treco.http.extractor.base import BaseExtractor, register_extractor
 
+
+@register_extractor('jpath', aliases=['jsonpath', 'json_path'])
 class JPathExtractor(BaseExtractor):
-    """Extractor implementation using JSONPath (JPath)."""
+    """
+    Extractor implementation using JSONPath (JPath).
+    
+    Supports JSONPath expressions to extract data from JSON responses.
+    Registered as 'jpath' with aliases 'jsonpath' and 'json_path'.
+    """
 
     def extract(self, response: requests.Response, pattern: str) -> Optional[Any]:
         """

--- a/src/treco/http/extractor/regex.py
+++ b/src/treco/http/extractor/regex.py
@@ -1,27 +1,28 @@
 """
-Data extractor using regex patterns.
+Regex extractor module.
 
-Extracts structured data from HTTP responses.
+Extracts data from HTTP responses using regular expression patterns.
 """
 
-from abc import abstractmethod
 import re
-from typing import Dict, Any, Optional
+import logging
+from typing import Any, Optional
 import requests
 
-import logging
-
-from treco.http.extractor.base import BaseExtractor
+from treco.http.extractor.base import BaseExtractor, register_extractor
 
 logger = logging.getLogger(__name__)
 
 
+@register_extractor('regex', aliases=['re', 'regexp', 'regular_expression'])
 class RegExExtractor(BaseExtractor):
     """
     Extracts data from HTTP responses using regex patterns.
 
     The extractor applies regex patterns to response text and
     captures groups as variables.
+    
+    Registered as 'regex' with aliases 're', 'regexp', and 'regular_expression'.
 
     Example:
         extractor = RegExExtractor()
@@ -43,20 +44,15 @@ class RegExExtractor(BaseExtractor):
 
         Args:
             response: HTTP response object
-            patterns: Dictionary of variable_name -> regex_pattern
+            pattern: Regex pattern string
 
         Returns:
-            Dictionary of extracted variables
+            Extracted value or None if not found
 
         Example:
-            patterns = {
-                "bearer_token": r'"token":\\s*"([^"]+)"',
-                "user_id": r'"id":\\s*(\\d+)',
-                "balance": r'"balance":\\s*(\\d+\\.?\\d*)'
-            }
-
-            extracted = extractor.extract(response, patterns)
-            # {"bearer_token": "xyz...", "user_id": "42", "balance": "1000"}
+            pattern = r'"bearer_token":\\s*"([^"]+)"'
+            extracted = extractor.extract(response, pattern)
+            # "xyz..."
         """
         response_text = response.text
 

--- a/src/treco/parser/validator.py
+++ b/src/treco/parser/validator.py
@@ -6,6 +6,8 @@ Validates YAML structure, required fields, and references.
 
 from typing import Dict, Any, Set
 
+from treco.http.extractor import get_extractor, ExtractorRegistry
+
 
 class ConfigValidator:
     """
@@ -233,13 +235,10 @@ class ConfigValidator:
                 )
 
             # Validate pattern_type
-            from treco.http.extractor import EXTRACTOR_REGISTRY
+            pattern_type = pattern.get("type", "regex")
 
-            valid_types = EXTRACTOR_REGISTRY.keys()
-
-            pattern_type = pattern["type"]
-            if pattern_type not in valid_types:
+            if not get_extractor(pattern_type):
                 raise ValueError(
                     f"State '{state_name}' extractor for variable '{var_name}' "
-                    f"has invalid pattern type: {pattern_type}. Valid types: {", ".join(list(valid_types))}"
+                    f"has invalid pattern type: {pattern_type}. Valid types: {", ".join(list(ExtractorRegistry.get_registered_types()))}"
                 )

--- a/src/treco/state/executor.py
+++ b/src/treco/state/executor.py
@@ -11,15 +11,12 @@ from dataclasses import dataclass
 import logging
 
 from treco.http.extractor import extract_all
-from treco.http.extractor.base import BaseExtractor
-from treco.models.config import ExtractPattern
-
 
 logger = logging.getLogger(__name__)
 
 from treco.models import State, ExecutionContext
 from treco.template import TemplateEngine
-from treco.http import HTTPClient, HTTPParser, Extractors
+from treco.http import HTTPClient
 
 
 @dataclass


### PR DESCRIPTION
- Add ExtractorRegistry class with decorator-based registration
- Create @register_extractor decorator with support for aliases
- Implement auto-discovery to load extractors automatically
- Update jpath and regex extractors to use the new decorator
- Remove manual EXTRACTOR_REGISTRY dict from __init__.py

New extractors can now be added by simply creating a new file with the @register_extractor decorator, no other code changes needed.